### PR TITLE
Fix: Replace ft.ImageFit with ft.BoxFit for Flet 0.80+ compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/andchir/flet_from_json/issues/3
-Your prepared branch: issue-3-c9c31098c08c
-Your prepared working directory: /tmp/gh-issue-solver-1767008630206
-Your forked repository: konard/andchir-flet_from_json
-Original repository (upstream): andchir/flet_from_json
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/andchir/flet_from_json/issues/3
+Your prepared branch: issue-3-c9c31098c08c
+Your prepared working directory: /tmp/gh-issue-solver-1767008630206
+Your forked repository: konard/andchir-flet_from_json
+Original repository (upstream): andchir/flet_from_json
+
+Proceed.

--- a/experiments/test_boxfit.py
+++ b/experiments/test_boxfit.py
@@ -1,0 +1,29 @@
+"""
+Experiment script to test BoxFit usage in Flet.
+"""
+import flet as ft
+
+print(f"Flet version: {ft.__version__}")
+print()
+
+# Test BoxFit
+print("Testing ft.BoxFit:")
+print(f"  ft.BoxFit = {ft.BoxFit}")
+print(f"  ft.BoxFit.CONTAIN = {ft.BoxFit.CONTAIN}")
+print(f"  ft.BoxFit.COVER = {ft.BoxFit.COVER}")
+print(f"  ft.BoxFit.FILL = {ft.BoxFit.FILL}")
+print()
+
+# Test creating an image with BoxFit
+print("Testing ft.Image with BoxFit:")
+img = ft.Image(
+    src="test.png",
+    fit=ft.BoxFit.CONTAIN,
+)
+print(f"  Image created successfully with fit={img.fit}")
+
+# All BoxFit values
+print()
+print("All BoxFit values:")
+for value in ft.BoxFit:
+    print(f"  {value.name} = {value.value}")

--- a/experiments/test_fix.py
+++ b/experiments/test_fix.py
@@ -1,0 +1,53 @@
+"""
+Test script to verify the ImageFit -> BoxFit fix works.
+This script imports the elements module and verifies it can be imported without error.
+"""
+import sys
+sys.path.insert(0, '/tmp/gh-issue-solver-1767008630206')
+
+print("Testing import of flet_from_json modules...")
+
+# Test 1: Import flet
+import flet as ft
+print(f"✓ Flet version: {ft.__version__}")
+
+# Test 2: Verify BoxFit exists
+print(f"✓ ft.BoxFit.CONTAIN = {ft.BoxFit.CONTAIN}")
+
+# Test 3: Import the elements module - this should not fail anymore
+try:
+    from flet_from_json.elements import ElementBuilder
+    print("✓ ElementBuilder imported successfully")
+except AttributeError as e:
+    print(f"✗ Import failed with AttributeError: {e}")
+    sys.exit(1)
+except Exception as e:
+    print(f"✗ Import failed with unexpected error: {e}")
+    sys.exit(1)
+
+# Test 4: Import the builder module
+try:
+    from flet_from_json.builder import JsonUIBuilder
+    print("✓ JsonUIBuilder imported successfully")
+except AttributeError as e:
+    print(f"✗ Import failed with AttributeError: {e}")
+    sys.exit(1)
+except Exception as e:
+    print(f"✗ Import failed with unexpected error: {e}")
+    sys.exit(1)
+
+# Test 5: Import the whole package
+try:
+    from flet_from_json import JsonUIBuilder, load_json_from_env
+    print("✓ flet_from_json package imported successfully")
+except AttributeError as e:
+    print(f"✗ Import failed with AttributeError: {e}")
+    sys.exit(1)
+except Exception as e:
+    print(f"✗ Import failed with unexpected error: {e}")
+    sys.exit(1)
+
+print()
+print("=" * 50)
+print("All tests passed! The ImageFit -> BoxFit fix is working.")
+print("=" * 50)

--- a/experiments/test_fix.py
+++ b/experiments/test_fix.py
@@ -3,7 +3,9 @@ Test script to verify the ImageFit -> BoxFit fix works.
 This script imports the elements module and verifies it can be imported without error.
 """
 import sys
-sys.path.insert(0, '/tmp/gh-issue-solver-1767008630206')
+import os
+# Add the parent directory to path so we can import flet_from_json
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 print("Testing import of flet_from_json modules...")
 

--- a/experiments/test_imagefit.py
+++ b/experiments/test_imagefit.py
@@ -1,0 +1,54 @@
+"""
+Experiment script to test different ways to access ImageFit in Flet.
+This helps determine the correct API for different Flet versions.
+"""
+import flet as ft
+
+try:
+    print(f"Flet version: {ft.__version__}")
+except:
+    print("Flet version: unknown")
+print()
+
+# Test different ways to access ImageFit
+print("Testing ft.ImageFit:")
+try:
+    print(f"  ft.ImageFit = {ft.ImageFit}")
+    print(f"  ft.ImageFit.CONTAIN = {ft.ImageFit.CONTAIN}")
+except AttributeError as e:
+    print(f"  Error: {e}")
+
+print()
+print("Testing ft.Image.fit with string value:")
+try:
+    # Some versions accept string values
+    img = ft.Image(src="test.png", fit="contain")
+    print(f"  String 'contain' works")
+except Exception as e:
+    print(f"  Error: {e}")
+
+print()
+print("Looking for ImageFit in flet module:")
+image_fit_attrs = [attr for attr in dir(ft) if 'fit' in attr.lower() or 'image' in attr.lower()]
+print(f"  Related attributes: {image_fit_attrs}")
+
+print()
+print("Looking for enums in flet module:")
+enum_attrs = [attr for attr in dir(ft) if not attr.startswith('_') and attr[0].isupper()]
+print(f"  Public classes/enums: {[a for a in enum_attrs[:50]]}")  # Show first 50
+
+print()
+print("Checking ft.Image class signature:")
+try:
+    import inspect
+    sig = inspect.signature(ft.Image.__init__)
+    print(f"  Image.__init__ params: {list(sig.parameters.keys())}")
+except Exception as e:
+    print(f"  Error: {e}")
+
+print()
+print("Looking for 'fit' related types:")
+for attr in dir(ft):
+    if 'fit' in attr.lower():
+        obj = getattr(ft, attr)
+        print(f"  ft.{attr} = {obj}")

--- a/flet_from_json/elements.py
+++ b/flet_from_json/elements.py
@@ -114,7 +114,7 @@ class ElementBuilder:
 
         image = ft.Image(
             src=value,
-            fit=ft.ImageFit.CONTAIN,
+            fit=ft.BoxFit.CONTAIN,
             border_radius=ft.border_radius.all(8) if element.get("roundedCorners", False) else None,
         )
 
@@ -321,7 +321,7 @@ class ElementBuilder:
                         ft.Text("Before", size=12, color=ft.Colors.GREY),
                         ft.Image(
                             src=value_first,
-                            fit=ft.ImageFit.CONTAIN,
+                            fit=ft.BoxFit.CONTAIN,
                             width=200,
                             border_radius=8,
                         ),
@@ -333,7 +333,7 @@ class ElementBuilder:
                         ft.Text("After", size=12, color=ft.Colors.GREY),
                         ft.Image(
                             src=value_second,
-                            fit=ft.ImageFit.CONTAIN,
+                            fit=ft.BoxFit.CONTAIN,
                             width=200,
                             border_radius=8,
                         ),


### PR DESCRIPTION
## Summary

- **Root Cause**: In Flet version 0.80.0+, the `ImageFit` enum has been renamed to `BoxFit`. The code was using `ft.ImageFit.CONTAIN` which no longer exists in newer Flet versions.
- **Fix**: Replaced all occurrences of `ft.ImageFit.CONTAIN` with `ft.BoxFit.CONTAIN` in `flet_from_json/elements.py`
- Added experiment scripts to document and test the Flet API changes

## Test Plan

- [x] Verified `ft.BoxFit.CONTAIN` exists in Flet 0.80.0
- [x] Verified the module imports successfully after the fix
- [x] Tested that `ElementBuilder` and `JsonUIBuilder` can be imported without `AttributeError`

## Technical Details

The fix addresses the following error:
```
AttributeError: module 'flet' has no attribute 'ImageFit'
```

In Flet 0.80.0, the API for image fitting was changed:
- Old API: `ft.ImageFit.CONTAIN`, `ft.ImageFit.COVER`, etc.
- New API: `ft.BoxFit.CONTAIN`, `ft.BoxFit.COVER`, etc.

This is consistent with Flutter's `BoxFit` enum which the Flet library wraps.

Fixes andchir/flet_from_json#3

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)